### PR TITLE
PARQUET-355: Use ColumnReaderImpl.

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderImpl.java
@@ -57,7 +57,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeNameConverter;
  * @author Julien Le Dem
  *
  */
-class ColumnReaderImpl implements ColumnReader {
+public class ColumnReaderImpl implements ColumnReader {
   private static final Log LOG = Log.getLog(ColumnReaderImpl.class);
 
   /**
@@ -149,8 +149,8 @@ class ColumnReaderImpl implements ColumnReader {
   private int dictionaryId;
 
   private long endOfPageValueCount;
-  private int readValues;
-  private int pageValueCount;
+  private int readValues = 0;
+  private int pageValueCount = 0;
 
   private final PrimitiveConverter converter;
   private Binding binding;


### PR DESCRIPTION
This changes the test implementation to use ColumnReaderImpl rather than
reimplementing parts of it. That change enables this to test
dictionary-encoded pages and this commit introduces contexts to test
them. This also cleans up a few minor issues that were artifacts of the
tests changing quite a bit, like the random value generators expecting a
PrimitiveTypeName that wasn't used.
